### PR TITLE
[MEET-47] Removed link prefix because of autolink feature

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 | - | -
 | ⏱ Review tijd | <!-- 5 min -->
 | ⌨️ Type wijziging | <!-- 🛠 Bug fix / ➕ Nieuwe feature / 🗒 Docs / 🤷🏻‍♂️ Overige -->
-| 🔗 Ticket | https://mv-jira-1.atlassian.net/browse/
+| 🔗 Ticket | <!-- DV-1337 -->
 
 ### ✍️ Wijzigingen
 <!-- Omschrijving van welke componenten er zijn gewijzigd en waarom. -->


### PR DESCRIPTION
| Q | A
| - | -
| ⏱ Review tijd | 30 sec
| ⌨️ Type wijziging | 🗒 Docs
| 🔗 Ticket | MEET-47

### ✍️ Wijzigingen
https://github.blog/2019-10-14-introducing-autolink-references/
